### PR TITLE
Performance improvements with large strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+syntax: glob
+build
+docs/_build
+dist
+MANIFEST
+PKG-INFO
+smartypants_command.py
+*.pyc

--- a/COPYING
+++ b/COPYING
@@ -23,7 +23,7 @@ SmartyPants
     the documentation and/or other materials provided with the
     distribution.
 
-  *   Neither the name "SmartyPants" nor the names of its contributors 
+  *   Neither the name "SmartyPants" nor the names of its contributors
     may be used to endorse or promote products derived from this
     software without specific prior written permission.
 
@@ -46,8 +46,9 @@ smartypants
 ::
 
   smartypants is a derivative work of SmartyPants.
-  
-  Copyright (c) 2013, 2014 Yu-Jie Lin
+
+  Copyright (c) 2017, Leo Hemsted
+  Copyright (c) 2013, 2014, 2015, 2016 Yu-Jie Lin
   Copyright (c) 2004, 2005, 2007, 2013 Chad Miller
 
   Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2013, 2014 by Yu-Jie Lin
+# Copyright (C) 2017 by Leo Hemsted
 # For detail license information, See COPYING
 
 from __future__ import print_function

--- a/smartypants
+++ b/smartypants
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2013, 2014 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 """

--- a/smartypants.py
+++ b/smartypants.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2017 Leo Hemsted
 # Copyright (c) 2013, 2014, 2016 Yu-Jie Lin
 # Copyright (c) 2004, 2005, 2007, 2013 Chad Miller
 # Copyright (c) 2003 John Gruber
@@ -12,11 +13,11 @@ smartypants module
 :func:`smartypants` is the core of smartypants module.
 """
 
-__author__ = 'Yu-Jie Lin'
-__author_email__ = 'livibetter@gmail.com'
-__version__ = '2.0.0'
+__author__ = 'Leo Hemsted'
+__author_email__ = 'leohemsted@gmail.com'
+__version__ = '2.1.0'
 __license__ = 'BSD License'
-__url__ = 'https://bitbucket.org/livibetter/smartypants.py'
+__url__ = 'https://github.com/leohemsted/smartypants.py'
 __description__ = 'Python with the SmartyPants'
 
 import re

--- a/smartypants.py
+++ b/smartypants.py
@@ -20,7 +20,13 @@ __license__ = 'BSD License'
 __url__ = 'https://github.com/leohemsted/smartypants.py'
 __description__ = 'Python with the SmartyPants'
 
-import re
+try:
+    import regex as re
+    # regex uses atomics to improve performance
+    TAG_REGEX = r'((?>[^<]*))(<!--.*?--\s*>|<[^>]*>)'
+except ImportError:
+    import re
+    TAG_REGEX = r'([^<]*)(<!--.*?--\s*>|<[^>]*>)'
 
 
 class _Attr(object):
@@ -213,7 +219,6 @@ def smartypants(text, attr=None):
     # the last character of the previous text
     # token, to use as context to curl single-
     # character quote tokens correctly.
-
     tags_to_skip_regex = _tags_to_skip_regex()
 
     for cur_token in tokens:
@@ -564,11 +569,15 @@ def _tokenize(text):
     Based on the _tokenize() subroutine from `Brad Choate's MTRegex plugin`__.
 
     __ http://www.bradchoate.com/past/mtregex.php
-    """
 
+
+    If you have the ``regex`` library (https://pypi.python.org/pypi/regex/),
+    this function will use an alternative regex to perform significantly faster
+    on large input texts.
+    """
     tokens = []
 
-    tag_soup = re.compile(r'([^<]*)(<!--.*?--\s*>|<[^>]*>)', re.S)
+    tag_soup = re.compile(TAG_REGEX, re.S)
 
     token_match = tag_soup.search(text)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2013, 2016 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import doctest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 from __future__ import unicode_literals

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2013, 2016 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import unittest

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import unittest


### PR DESCRIPTION
TL;DR: Speed up `_tokenize` by using a 3rd party regex lib.

# The problem: 

`_tokenize` identifies html tags in text (since smartypants doesn't touch stuff inside tags). Smartypantsifying in a large (8400 character) string with no tags or even angle brackets in was proving to be prohibitively slow (0.5 seconds).

# The solution:

`regex` is a [PCRE](https://www.pcre.org/)-compliant 3rd party library - we can take advantage of [atomic groups](https://www.regular-expressions.info/atomic.html) to prevent backtracking attempts (the second half of the regex, which matches the tag, would try to backtrack into the first group, of non `<` characters, trying to find a `<`). 

This is an optional improvement - if `regex` is not installed it'll fall back to the older, slower regex.

Speed up is significant - from 0.58 to 0.037 for my test input.

![image](https://user-images.githubusercontent.com/5020841/33479525-5974accc-d685-11e7-8aff-601bcfdee4fb.png)

With thanks to James Kirrage