### PR TITLE
Use match instead of search.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+syntax: glob
+build
+docs/_build
+dist
+MANIFEST
+PKG-INFO
+smartypants_command.py
+*.pyc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Releases 2.0 and greater
 Development
 -----------
 
+* use `re.match` instead of `re.search` to improve performance on large strings
 
 Release 2.0.0 (2016-12-28T06:18:42Z)
 ------------------------------------

--- a/COPYING
+++ b/COPYING
@@ -23,7 +23,7 @@ SmartyPants
     the documentation and/or other materials provided with the
     distribution.
 
-  *   Neither the name "SmartyPants" nor the names of its contributors 
+  *   Neither the name "SmartyPants" nor the names of its contributors
     may be used to endorse or promote products derived from this
     software without specific prior written permission.
 
@@ -46,8 +46,9 @@ smartypants
 ::
 
   smartypants is a derivative work of SmartyPants.
-  
-  Copyright (c) 2013, 2014 Yu-Jie Lin
+
+  Copyright (c) 2017, Leo Hemsted
+  Copyright (c) 2013, 2014, 2015, 2016 Yu-Jie Lin
   Copyright (c) 2004, 2005, 2007, 2013 Chad Miller
 
   Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2013, 2014 by Yu-Jie Lin
+# Copyright (C) 2017 by Leo Hemsted
 # For detail license information, See COPYING
 
 from __future__ import print_function

--- a/smartypants
+++ b/smartypants
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2013, 2014 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 """

--- a/smartypants.py
+++ b/smartypants.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright (c) 2017 Leo Hemsted
 # Copyright (c) 2013, 2014, 2016 Yu-Jie Lin
 # Copyright (c) 2004, 2005, 2007, 2013 Chad Miller
 # Copyright (c) 2003 John Gruber
@@ -12,11 +13,11 @@ smartypants module
 :func:`smartypants` is the core of smartypants module.
 """
 
-__author__ = 'Yu-Jie Lin'
-__author_email__ = 'livibetter@gmail.com'
+__author__ = 'Leo Hemsted'
+__author_email__ = 'leohemsted@gmail.com'
 __version__ = '2.0.0'
 __license__ = 'BSD License'
-__url__ = 'https://bitbucket.org/livibetter/smartypants.py'
+__url__ = 'https://github.com/leohemsted/smartypants.py'
 __description__ = 'Python with the SmartyPants'
 
 import re

--- a/smartypants.py
+++ b/smartypants.py
@@ -15,7 +15,7 @@ smartypants module
 
 __author__ = 'Leo Hemsted'
 __author_email__ = 'leohemsted@gmail.com'
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 __license__ = 'BSD License'
 __url__ = 'https://github.com/leohemsted/smartypants.py'
 __description__ = 'Python with the SmartyPants'
@@ -570,7 +570,7 @@ def _tokenize(text):
 
     tag_soup = re.compile(r'([^<]*)(<!--.*?--\s*>|<[^>]*>)', re.S)
 
-    token_match = tag_soup.search(text)
+    token_match = tag_soup.match(text)
 
     previous_end = 0
     while token_match:
@@ -600,7 +600,7 @@ def _tokenize(text):
         tokens.append([type_, tag])
 
         previous_end = token_match.end()
-        token_match = tag_soup.search(text, token_match.end())
+        token_match = tag_soup.match(text, token_match.end())
 
     if previous_end < len(text):
         tokens.append(['text', text[previous_end:]])

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2013, 2016 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import doctest

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,6 +5,7 @@
 
 import doctest
 import unittest
+from time import time
 
 import smartypants
 from smartypants import smartypants as sp
@@ -146,6 +147,16 @@ document.write('<a href="' + href + '">' + linktext + "</a>");
 
         self.assertEqual(sp('"quote here"', Attr.set1 | Attr.s),
                          '"quote here"')
+
+    def test_incredibly_long_string(self):
+        # make sure it doesn't take too long with a long string
+        start = time()
+
+        sp("a" * 10000)
+
+        end = time()
+
+        self.assertLess(end - start, 0.2)
 
 
 def load_tests(loader, tests, pattern):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 from __future__ import unicode_literals

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2013, 2016 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import unittest

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Yu-Jie Lin
+# Copyright (c) 2017 Leo Hemsted
 # Licensed under the BSD License, for detailed license information, see COPYING
 
 import unittest


### PR DESCRIPTION
🐎 

See https://github.com/leohemsted/smartypants.py/pull/1#discussion_r154527963 for more information. Added a test that'll fail if the function takes longer than 0.2 seconds (`re.search` took 0.84 and `re.match` takes 0.002 secs 🐎💨)