### PR TITLE
Add support for German and French quotes

### DIFF
--- a/smartypants.py
+++ b/smartypants.py
@@ -49,6 +49,13 @@ class _Attr(object):
     """
     mask_b = b | B
 
+    c = 1 << 10
+    """
+    flag for comma quotes (``,,``) and (``````) to curly ones.
+
+    .. seealso:: :func:`convert_comma_quotes`
+    """
+
     d = 1 << 3
     """
     flag for dashes (``--``) to em-dashes.
@@ -118,8 +125,8 @@ class _Attr(object):
 
     set0 = 0
     "suppress all transformations. (Do nothing.)"
-    set1 = q | b | d | e
-    "equivalent to :attr:`q` | :attr:`b` | :attr:`d` | :attr:`e`"
+    set1 = q | b | c | d | e
+    "equivalent to :attr:`q` | :attr:`b` | :attr:`c`| :attr:`d` | :attr:`e`"
     set2 = q | b | D | e
     """
     equivalent to :attr:`q` | :attr:`b` | :attr:`D` | :attr:`e`
@@ -197,6 +204,7 @@ def smartypants(text, attr=None):
 
     do_quotes = attr & Attr.q
     do_backticks = attr & Attr.mask_b
+    do_commas = attr & Attr.c
     do_dashes = attr & Attr.mask_d
     do_ellipses = attr & Attr.e
     do_entities = attr & Attr.mask_o
@@ -257,6 +265,9 @@ def smartypants(text, attr=None):
 
                 if do_ellipses:
                     t = convert_ellipses(t)
+
+                if do_commas == Attr.c:
+                    t = convert_comma_quotes(t)
 
                 # Note: backticks need to be processed before quotes.
                 if do_backticks == Attr.b:
@@ -415,6 +426,19 @@ def convert_single_backticks(text):
 
     text = re.sub('`', '&#8216;', text)
     text = re.sub("'", '&#8217;', text)
+    return text
+
+
+def convert_comma_quotes(text):
+    """
+    Convert ``,,comma````-style double quotes in *test* into HTML curly quote
+    entities (low-9 aka German style).
+
+    >>> print(convert_comma_quotes(",,Isn't this fun?``"))
+    &#8222;Isn't this fun?&#8220;
+    """
+    text = re.sub(',,', '&#8222;', text)
+    text = re.sub('``', '&#8220;', text)
     return text
 
 

--- a/smartypants.py
+++ b/smartypants.py
@@ -56,6 +56,13 @@ class _Attr(object):
     .. seealso:: :func:`convert_comma_quotes`
     """
 
+    g = 1 << 11
+    """
+    flag for less-than and greater-than signs (``<<``) and (``>>``) to
+    guillemets.
+
+    .. seealso:: :func:`convert_guillemets`
+    """
     d = 1 << 3
     """
     flag for dashes (``--``) to em-dashes.
@@ -125,8 +132,11 @@ class _Attr(object):
 
     set0 = 0
     "suppress all transformations. (Do nothing.)"
-    set1 = q | b | c | d | e
-    "equivalent to :attr:`q` | :attr:`b` | :attr:`c`| :attr:`d` | :attr:`e`"
+    set1 = q | b | c | g | d | e
+    """
+    equivalent to :attr:`q` | :attr:`b` | :attr:`c`| :attr:`g`| :attr:`d`
+    | :attr:`e`
+    """
     set2 = q | b | D | e
     """
     equivalent to :attr:`q` | :attr:`b` | :attr:`D` | :attr:`e`
@@ -205,6 +215,7 @@ def smartypants(text, attr=None):
     do_quotes = attr & Attr.q
     do_backticks = attr & Attr.mask_b
     do_commas = attr & Attr.c
+    do_guillemets = attr & Attr.g
     do_dashes = attr & Attr.mask_d
     do_ellipses = attr & Attr.e
     do_entities = attr & Attr.mask_o
@@ -268,6 +279,9 @@ def smartypants(text, attr=None):
 
                 if do_commas == Attr.c:
                     t = convert_comma_quotes(t)
+
+                if do_guillemets == Attr.g:
+                    t = convert_guillemets(t)
 
                 # Note: backticks need to be processed before quotes.
                 if do_backticks == Attr.b:
@@ -442,6 +456,19 @@ def convert_comma_quotes(text):
     return text
 
 
+def convert_guillemets(text):
+    """
+    Convert ``<<angle>>``-style double quotes in *test* into HTML guillemet
+    entities (French style).
+
+    >>> print(convert_guillemets("<<Isn't this fun?>>"))
+    &#171;Isn't this fun?&#187;
+    """
+    text = re.sub('<<', '&#171;', text)
+    text = re.sub('>>', '&#187;', text)
+    return text
+
+
 def convert_dashes(text):
     """
     Convert ``--`` in *text* into em-dash HTML entities.
@@ -592,7 +619,7 @@ def _tokenize(text):
 
     tokens = []
 
-    tag_soup = re.compile(r'([^<]*)(<!--.*?--\s*>|<[^>]*>)', re.S)
+    tag_soup = re.compile(r'([^<]*)(<!--.*?--\s*>|<[^<>]*>)', re.S)
 
     token_match = tag_soup.match(text)
 


### PR DESCRIPTION
Implement converting:

- ```,,German style quotes`` ``` &rarr; &#8222;German style quotes&#8220;
- ``<<French style quotes>>`` &rarr; &#171;French style quotes&#187;

Inspired by the [PHP implementation](https://github.com/michelf/php-smartypants).