### PR TITLE
Fix double closing quotes after an HTML block

### DIFF
--- a/smartypants.py
+++ b/smartypants.py
@@ -379,6 +379,13 @@ def convert_quotes(text):
     text = closing_double_quotes_regex.sub('&#8221;', text)
 
     closing_double_quotes_regex = re.compile(r"""
+            ^
+            "
+            (?=%s)
+            """ % (punct_class,), re.VERBOSE)
+    text = closing_double_quotes_regex.sub('&#8221;', text)
+
+    closing_double_quotes_regex = re.compile(r"""
             (%s)   # character that indicates the quote should be closing
             "
             """ % (close_class,), re.VERBOSE)

--- a/tests/test.py
+++ b/tests/test.py
@@ -135,6 +135,20 @@ document.write('<a href="' + href + '">' + linktext + "</a>");
         self.assertEqual(sp('"Isn\'t this fun?"'),
                          '&#8220;Isn&#8217;t this fun?&#8221;')
 
+    def test_quotes_punctuation(self):
+
+        self.assertEqual(sp('You should use ";" here'),
+                         'You should use &#8220;;&#8221; here')
+
+    def test_quotes_and_html(self):
+
+        self.assertEqual(
+            sp('Take a look at the "<a>Essay on quoting</a>" paper.'),
+            'Take a look at the &#8220;<a>Essay on quoting</a>&#8221; paper.')
+        self.assertEqual(
+            sp('Take a look at "<a>Essay on quoting</a>".'),
+            'Take a look at &#8220;<a>Essay on quoting</a>&#8221;.')
+
     def test_convert_entities(self):
 
         self.assertEqual(sp('"quote here"', Attr.set1 | Attr.u),


### PR DESCRIPTION
The double closing quote happens to be at the beginning. If it is
followed by a space, everything is OK, but if it is followed by a
punctuation, we get the default opening quote instead. Fix that by
using closing tag when there is punctuation.

This is not really generic because we do not want to break other
cases, like quoting a punctuation character.