### PR TITLE
A flag to disable backslash-escaping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ Changes
 Releases 2.0 and greater
 ========================
 
+Unreleased
+----------
+
++ Add ``Attr.n`` to disable escape processing.
+
 Release 2.0.1 (2017-12-20)
 --------------------------
 

--- a/smartypants.py
+++ b/smartypants.py
@@ -114,6 +114,11 @@ class _Attr(object):
 
     .. seealso:: :func:`convert_entities`
     """
+    n = 1 << 10
+    """
+    Disable backslash escape processing by :func:`process_escapes`.
+    """
+
     mask_o = u | h | s
 
     set0 = 0
@@ -201,6 +206,7 @@ def smartypants(text, attr=None):
     do_ellipses = attr & Attr.e
     do_entities = attr & Attr.mask_o
     convert_quot = attr & Attr.w
+    do_escapes = not(attr & Attr.n)
 
     tokens = _tokenize(text)
     result = []
@@ -242,7 +248,8 @@ def smartypants(text, attr=None):
             # Remember last char of this token before processing.
             last_char = t[-1:]
             if not in_pre:
-                t = process_escapes(t)
+                if do_escapes:
+                    t = process_escapes(t)
 
                 if convert_quot:
                     t = re.sub('&quot;', '"', t)
@@ -518,7 +525,7 @@ def convert_entities(text, mode):
 
 def process_escapes(text):
     r"""
-    Processe the following backslash escape sequences in *text*. This is useful
+    Process the following backslash escape sequences in *text*. This is useful
     if you want to force a "dumb" quote or other character to appear.
 
     +--------+-----------+-----------+
@@ -541,6 +548,9 @@ def process_escapes(text):
     &#92;
     >>> print(smartypants(r'"smarty" \"pants\"'))
     &#8220;smarty&#8221; &#34;pants&#34;
+
+    This processing can be disabled with the ``Attr.n`` flag.
+
     """
 
     text = re.sub(r'\\\\', '&#92;', text)

--- a/smartypants.py
+++ b/smartypants.py
@@ -275,13 +275,13 @@ def smartypants(text, attr=None):
                 if do_quotes:
                     if t == "'":
                         # Special case: single-character ' token
-                        if re.match("\S", prev_token_last_char):
+                        if re.match(r"\S", prev_token_last_char):
                             t = "&#8217;"
                         else:
                             t = "&#8216;"
                     elif t == '"':
                         # Special case: single-character " token
-                        if re.match("\S", prev_token_last_char):
+                        if re.match(r"\S", prev_token_last_char):
                             t = "&#8221;"
                         else:
                             t = "&#8220;"

--- a/tests/test.py
+++ b/tests/test.py
@@ -158,6 +158,17 @@ document.write('<a href="' + href + '">' + linktext + "</a>");
 
         self.assertLess(end - start, 0.2)
 
+    def test_escapes(self):
+        TEXT = r'"smarty" regex: "[\-\.]"'
+
+        T = sp(TEXT)
+        E = r'&#8220;smarty&#8221; regex: &#8220;[&#45;&#46;]&#8221;'
+        self.assertEqual(T, E)
+
+        T = sp(TEXT, Attr.q | Attr.n)
+        E = r'&#8220;smarty&#8221; regex: &#8220;[\-\.]&#8221;'
+        self.assertEqual(T, E)
+
 
 def load_tests(loader, tests, pattern):
 


### PR DESCRIPTION
I added `Attr.n` to disable escape processing.

I write a technical blog, and have had blog posts look wrong because I mention regexes like `[.\-]`.  I don't want to have to think about smartypants while I write, so I won't use the backslashes on purpose, and don't want them by accident.